### PR TITLE
Use beautiful unicode identifiers.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "kind-projector"
 
 organization := "org.spire-math"
 
-version := "0.5.2"
+version := "0.6.0"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.4"
 
 seq(bintrayResolverSettings: _*)
 
@@ -25,7 +25,7 @@ scalacOptions in Test <+= (packageBin in Compile) map {
   pluginJar => "-Xplugin:" + pluginJar
 }
 
-crossScalaVersions := Seq("2.9.3", "2.11.0")
+crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.4")
 
 seq(bintrayPublishSettings: _*)
 

--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -122,10 +122,10 @@ class KindRewriter(plugin: Plugin, val global: Global)
               ValDef(Modifiers(0), "_", TypeTree(), EmptyTree),
               TypeDef(
                 Modifiers(0),
-                newTypeName("L_kp"),
+                newTypeName("Λ"),
                 innerTypes,
                 super.transform(subtree)) :: Nil)),
-          newTypeName("L_kp"))
+          newTypeName("Λ"))
 
       // This method handles the explicit type lambda case, e.g.
       // Lambda[(A, B) => Function2[A, Int, B]] case.
@@ -162,9 +162,9 @@ class KindRewriter(plugin: Plugin, val global: Global)
         // create a new type argument list, catching placeholders and create
         // individual identifiers for them.
         val xyz = as.zipWithIndex.map {
-          case (Ident(Placeholder), i) => (Ident(newTypeName("X_kp%d" format i)), Some(Placeholder))
-          case (Ident(CoPlaceholder), i) => (Ident(newTypeName("X_kp%d" format i)), Some(CoPlaceholder))
-          case (Ident(ContraPlaceholder), i) => (Ident(newTypeName("X_kp%d" format i)), Some(ContraPlaceholder))
+          case (Ident(Placeholder), i) => (Ident(newTypeName("α%d" format i)), Some(Placeholder))
+          case (Ident(CoPlaceholder), i) => (Ident(newTypeName("α%d" format i)), Some(CoPlaceholder))
+          case (Ident(ContraPlaceholder), i) => (Ident(newTypeName("α%d" format i)), Some(ContraPlaceholder))
           case (a, i) => (super.transform(a), None)
         }
 

--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -126,10 +126,10 @@ class KindRewriter(plugin: Plugin, val global: Global)
               ValDef(Modifiers(0), "_", TypeTree(), EmptyTree),
               TypeDef(
                 Modifiers(0),
-                newTypeName("Λ"),
+                newTypeName("_Λ"),
                 innerTypes,
                 super.transform(subtree)) :: Nil)),
-          newTypeName("Λ"))
+          newTypeName("_Λ"))
 
       // This method handles the explicit type lambda case, e.g.
       // Lambda[(A, B) => Function2[A, Int, B]] case.


### PR DESCRIPTION
This commit changes the way type lambdas are encoded.
Currently, the encoding looks like this:

`Function2[?, Int, ?]` becomes:
  `({type L_kp[X_kp0, X_kp2] = Function2[X_kp0, Int, X_kp2]})#L_kp`

With this commit, it would instead be:
  `({type Λ[α0, α2] = Function2[α0, Int, α2]})#Λ`

Benefits of this change:

1. Encoding looks better.
2. Error messages are much cleaner.
3. Closer to existing community conventions.

Drawbacks to this change:

1. Requires users to be able to display unicode.
2. Complicates using types named "Λ", "α0", etc. with kind-projector.

Overall, I think this would be a win, but I'll have to canvas opinions.