### PR TITLE
Type bounds proof-of-concept.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ scalacOptions in Test <+= (packageBin in Compile) map {
   pluginJar => "-Xplugin:" + pluginJar
 }
 
-crossScalaVersions := Seq("2.9.3", "2.11.0")
+crossScalaVersions := Seq("2.10.4", "2.11.4")
 
 seq(bintrayPublishSettings: _*)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "org.spire-math"
 
 version := "0.5.2"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.4"
 
 seq(bintrayResolverSettings: _*)
 

--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -78,8 +78,10 @@ class KindRewriter(plugin: Plugin, val global: Global)
       def makeTypeParamFromName(name: Name) = {
         val decoded = NameTransformer.decode(name.toString)
         val src = s"type _X_[$decoded] = Unit"
-        val TypeDef(_, _, List(tpe), _) = sp.parse(src)
-        tpe
+        sp.parse(src) match {
+          case Some(TypeDef(_, _, List(tpe), _)) => tpe
+          case None => unit.error(tree.pos, s"Can't parse param: $name"); null
+        }
       }
 
       // Like makeTypeParam, but can be used recursively in the case of types

--- a/src/main/scala/StringParser.scala
+++ b/src/main/scala/StringParser.scala
@@ -6,19 +6,16 @@ import scala.tools.nsc.reporters.StoreReporter
 
 class StringParser[G <: Global](val global: G) {
   import global._
-  def parse(code: String): Tree = {
-    val sreporter = new StoreReporter()
+  def parse(code: String): Option[Tree] = {
     val oldReporter = global.reporter
     try {
-      global.reporter = sreporter
-      val parser = newUnitParser(new CompilationUnit(newSourceFile(code, "<kp>")))
-      val tree = gen.mkTreeOrBlock(parser.parseStatsOrPackages())
-      sreporter.infos.foreach {
-        case sreporter.Info(pos, msg, sreporter.ERROR) =>
-          throw ParseException(pos, msg)
-      }
-      tree
-    } finally global.reporter = oldReporter
+      val r = new StoreReporter()
+      global.reporter = r
+      val tree = newUnitParser(code).templateStats().headOption
+      if (r.infos.isEmpty) tree else None
+    } finally {
+      global.reporter = oldReporter
+    }
   }
 }
 

--- a/src/main/scala/StringParser.scala
+++ b/src/main/scala/StringParser.scala
@@ -1,0 +1,24 @@
+package d_m
+
+import scala.reflect.macros.ParseException
+import scala.tools.nsc.Global
+import scala.tools.nsc.reporters.StoreReporter
+
+class StringParser[G <: Global](val global: G) {
+  import global._
+  def parse(code: String): Tree = {
+    val sreporter = new StoreReporter()
+    val oldReporter = global.reporter
+    try {
+      global.reporter = sreporter
+      val parser = newUnitParser(new CompilationUnit(newSourceFile(code, "<kp>")))
+      val tree = gen.mkTreeOrBlock(parser.parseStatsOrPackages())
+      sreporter.infos.foreach {
+        case sreporter.Info(pos, msg, sreporter.ERROR) =>
+          throw ParseException(pos, msg)
+      }
+      tree
+    } finally global.reporter = oldReporter
+  }
+}
+

--- a/src/test/scala/bounds.scala
+++ b/src/test/scala/bounds.scala
@@ -1,0 +1,13 @@
+package bounds
+
+trait Leibniz[-L, +H >: L, A >: L <: H, B >: L <: H]
+
+object Test {
+  trait Foo
+  trait Bar extends Foo
+
+  def outer[A >: Bar <: Foo] = {
+    def test[F[_ >: Bar <: Foo]] = 999
+    test[λ[`b >: Bar <: Foo` => Leibniz[Bar, Foo, A, b]]]
+  }
+}


### PR DESCRIPTION
This commit adds basic type bound support. With it, you can
do the following:

    Lambda[`a <: Foo` => ...]
    Lambda[`b >: Bar` => ...]
    Lambda[`c` >: Bar <: Foo` => ...]

You can also use dots in the type bounds, e.g.:

    Lambda[`a <: scala.runtime.RichInt` => ...]

Not yet supported:

 * Parameterized bounds, e.g. `a <: List[Int]`
 * Mixin bounds, e.g. `a <: Foo with Bar`
 * Existential bounds, e.g. `a <: Foo[X] forSome { type X }`
 * ...and probably much more

It's not clear how to proceed here. Reimplementing the entire
parser in this plugin is clearly a bad idea. But at least some
of the unsupported bounds are probably important.

(It would be nice to actually use the Scala parser for this but
I'm not sure how easy it would be to do that. I'm not holding
my breath.)

One option is to figure out a basic set of "supported bounds"
and fail the compilation with a nice, human-readable explanation
that the bounds were not supported if "invalid" bounds are seen.

Works towards fixing #5.