### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ expressions.
 
 ```scala
 Either[Int, ?]
-({type Λ$[β] = (Int, β)})#Λ$
+({type Λ$[β] = Either[Int, β]})#Λ$
 
 Function2[-?, String, +?]
 ({type Λ$[-α, +γ] = Function2[α, String, γ]})#Λ$


### PR DESCRIPTION
Either[Int, ?] is converted into ({type Λ$[β] = Either[Int, β]})#Λ$
It is not equivalent to ({type Λ$[β] = (Int, β)})#Λ$, which is what Tuple2[Int, ?] may be converted to