### PR TITLE
Improve the efficiency of kind-projector.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,11 @@ homepage := Some(url("http://github.com/non/kind-projector"))
 scalaVersion := "2.11.7"
 crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.0-M3")
 
-libraryDependencies <++= (scalaVersion) {
-  v => Seq("org.scala-lang" % "scala-compiler" % v)
+libraryDependencies <++= (scalaVersion) { v =>
+  Seq("org.scala-lang" % "scala-compiler" % v)
 }
+
+libraryDependencies += "com.chuusai"  %% "shapeless" % "2.2.2" % "test"
 
 // scalac options
 

--- a/src/test/scala/hmm.scala
+++ b/src/test/scala/hmm.scala
@@ -1,0 +1,53 @@
+package hmm
+
+import shapeless._
+
+class TC[A]
+
+object TC {
+
+  def apply[A](implicit ev: TC[A]) =
+    ev
+
+  implicit val IntTC: TC[Int] =
+    new TC[Int]
+
+  implicit def deriveHNil: TC[HNil] =
+    new TC[HNil]
+
+  implicit def deriveHCons[H, T <: HList](implicit H: TC[H], T: TC[T]): TC[H :: T] =
+    new TC[H :: T]
+
+  // not required for this example
+  implicit def deriveInstance[F, G](implicit gen: Generic.Aux[F, G], G: TC[G]): TC[F] =
+    new TC[F]
+}
+
+object test {
+  TC[Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+   Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+   Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: HNil]
+
+  TC[Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: HNil]
+
+  TC[Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: HNil]
+}


### PR DESCRIPTION
This fixes an issue raised by tpolecat where kind-projector
caused scalac to seem to hang when used with large hlist
types and shapeless. Kind-projector syntax was not being
used, so it seemed like the tree transformers were somehow
taking too long.

The problem ended up being that there was a quadratic
slowdown when kp parsed recursive types like hlists.
The solution was to cache (memoize) the `Tree => Tree`
transformation, to ensure that we don't recompute
these trees many times.

It would be nice if we could somehow clear this cache
between source files, or top-level classes, to avoid
using huge amounts of memory during compilation. I'm
going to explore that now.