### PR TITLE
Fix #20: shadowing warning with KP in nested context

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ avoid defining the following identifiers:
  1. `Lambda` and `λ`
  2. `?`, `+?`, and `-?`
  4. `Λ$`
- 5. `α`, `β`, ...
+ 5. `α$`, `β$`, ...
 
 If you find yourself using lots of type lambdas, and you don't mind
 reserving those identifiers, then this compiler plugin is for you!
@@ -200,10 +200,10 @@ expressions.
 
 ```scala
 Either[Int, ?]
-({type Λ$[β] = Either[Int, β]})#Λ$
+({type Λ$[β$0$] = Either[Int, β$0$]})#Λ$
 
 Function2[-?, String, +?]
-({type Λ$[-α, +γ] = Function2[α, String, γ]})#Λ$
+({type Λ$[-α$0$, +γ$0$] = Function2[α$0$, String, γ$0$]})#Λ$
 
 Lambda[A => (A, A)]
 ({type Λ$[A] = (A, A)})#Λ$
@@ -215,12 +215,12 @@ Lambda[(A, B[_]) => B[A]]
 ({type Λ$[A, B[_]] = B[A]})#Λ$
 ```
 
-As you can see, names like `Λ$` and `α` are forbidden because they
+As you can see, names like `Λ$` and `α$` are forbidden because they
 might conflict with names the plugin generates.
 
 If you dislike these unicode names, pass `-Dkp:genAsciiNames=true` to
 scalac to use munged ASCII names. This will use `L_kp` in place of
-`Λ$`, `X_kp0` in place of `α`, and so on.
+`Λ$`, `X_kp0$` in place of `α$`, and so on.
 
 ### Building the plugin
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
 // scalac options
 
 scalacOptions ++= Seq(
+  "-Xfatal-warnings",
+  "-Xlint",
   "-feature",
   "-language:higherKinds",
   "-deprecation",

--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -59,29 +59,42 @@ class KindRewriter(plugin: Plugin, val global: Global)
     val Plus = newTypeName("$plus")
     val Minus = newTypeName("$minus")
 
+    private var cnt = -1 // So we actually start naming from 0
+
+    @inline
+    private def freshName(s: String) = {
+      cnt += 1
+      s + cnt + "$"
+    }
+
     /**
      * Produce type lambda param names.
      *
-     * If useAsciiNames is set, the legacy names (X_kp0, X_kp1, etc)
+     * The name is always appended with a unique number for the compilation
+     * unit to prevent shadowing of names in a nested context.
+     *
+     * If useAsciiNames is set, the legacy names (X_kp0$, X_kp1$, etc)
      * will be used.
      *
      * Otherwise:
      *
-     * The first parameter (i=0) will be α, the second β, and so on.
-     * After producing ω (for i=24), the letters wrap back around with
-     * a number appended, e.g. α1, β1, and so on.
+     * The first parameter (i=0) will be α$, the second β$, and so on.
+     * After producing ω$ (for i=24), the letters wrap back around with
+     * a number appended, e.g. α$1$, β$1$, and so on.
      */
     def newParamName(i: Int): TypeName = {
       require(i >= 0)
-      if (useAsciiNames) {
-        newTypeName("X_kp%d" format i)
-      } else {
-        val j = i % 25
-        val k = i / 25
-        val c = ('α' + j).toChar
-        val s = if (k == 0) s"$c" else s"$c$k"
-        newTypeName(s)
+      val name = {
+        if (useAsciiNames) {
+          "X_kp%d".format(i) + "$"
+        } else {
+          val j = i % 25
+          val k = i / 25
+          val c = ('α' + j).toChar
+          if (k == 0) s"$c$$" else s"$c$$$k$$"
+        }
       }
+      newTypeName(freshName(name))
     }
 
     // Define some names (and bounds) that will come in handy.

--- a/src/test/scala/nested.scala
+++ b/src/test/scala/nested.scala
@@ -1,0 +1,13 @@
+package nested
+
+// From https://github.com/non/kind-projector/issues/20
+import scala.language.higherKinds
+
+object KindProjectorWarnings {
+  trait Foo[F[_], A]
+  trait Bar[A, B]
+
+  def f[G[_]]: Unit = ()
+
+  f[Foo[Bar[Int, ?], ?]] // shadowing warning
+}


### PR DESCRIPTION
This PR originally started out to fix the REAME warning to avoid using "α, β, ..." and then included #20 