### PR TITLE
Update to scala 2.12-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 homepage := Some(url("http://github.com/non/kind-projector"))
 
 scalaVersion := "2.11.7"
-crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.0-M4")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M5")
 
 libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
 


### PR DESCRIPTION
I'm trying to update doobie to scalaz-stream 0.8.4a, but the cross build to 2.12 isn't working because kind projector doesn't have a 2.12-M5 version. Also bumped the 2.11 version because I didn't see any reason not to. https://github.com/tpolecat/doobie/pull/332 