### PR TITLE
[Experimental] Minimal support for universally quantified values.

### DIFF
--- a/src/test/scala/forall.scala
+++ b/src/test/scala/forall.scala
@@ -1,0 +1,38 @@
+package forall
+
+import scala.language.reflectiveCalls
+
+object Foralls {
+  val nil: ∀[A => List[A]] = ∀[A => List[A]](Nil)
+  val is: List[Int] = nil[Int]
+
+  val right: ∀[A => Either[A, Int]] = ∀[A => Either[A, Int]](Right(42))
+  val e: Either[String, Int] = right[String]
+
+  trait Monoid[A] {
+    def zero: A
+    def combine(a1: A, a2: A): A
+  }
+
+  def listMonoid[A]: Monoid[List[A]] = new Monoid[List[A]] {
+    def zero = Nil
+    def combine(l1: List[A], l2: List[A]): List[A] = l1 ++ l2
+  }
+
+  type MonoidK[F[_]] = ∀[A => Monoid[F[A]]]
+  val listMonoidK: MonoidK[List] = ∀[A => Monoid[List[A]]](listMonoid)
+
+  val l: List[Int] = listMonoidK().combine(List(1, 2, 3), List(4, 5, 6))
+
+  type ~>[F[_], G[_]] = ∀[A => F[A] => G[A]]
+  val headOption = ∀[A => List[A] => Option[A]](_.headOption)
+
+  val h: Option[Int] = headOption()(l)
+
+
+  type Forall[F[_]] = ∀[A => F[A]]
+
+  // nested ∀s not yet working
+  // type Exists[F[_]] = ∀[B => ∀[A => F[A] => B] => B]
+
+}


### PR DESCRIPTION
In type position,

```scala
∀[A => F[A]]
```

is rewritten to structural type

```scala
{ def apply[A](): F[A] }
```

In term position,

```scala
∀[A => F[A]](fa)
```

is rewritten to

```scala
new { def apply[A](): F[A] = fa }
```

#### Example

```scala
val right = ∀[A => Either[A, Int]](Right(42))
val e: Either[String, Int] = right[String]
```

See more examples in tests.

### Shortcomings / TODOs

#### Reflection (structural types)

Invocation of a method on a structural type uses reflection.

Defining a supertype like

```scala
trait ForAll[F[_]] {
  def apply[A](): F[A]
}
```

would restrict the type constructors to the kind `* -> *`, so I went with structural types. Ideas on how to both support arbitrary kinds and avoid reflection are welcome.

#### Nested `∀`s

Nested `∀`s don't work yet:

```scala
type Exists[F[_]] = ∀[B => ∀[A => F[A] => B] => B]
```

gives `not found: type ∀` for the inner `∀`.

#### Syntax

It would be nice if instead of

```scala
∀[A => List[A]]
```

one could write

```scala
∀[List]
```

It is unlikely this will be made possible, since information about `List`'s type parameters is absent in this syntax tree.

I can imagine this to be supported instead:

```scala
∀[List[?]]
```