### PR TITLE
Linted unused imports on 2.12.2

### DIFF
--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -2,15 +2,12 @@ package d_m
 
 import scala.tools.nsc
 import nsc.Global
-import nsc.Phase
 import nsc.plugins.Plugin
 import nsc.plugins.PluginComponent
 import nsc.transform.Transform
-import nsc.transform.InfoTransform
 import nsc.transform.TypingTransformers
 import nsc.symtab.Flags._
 import nsc.ast.TreeDSL
-import nsc.typechecker
 
 import scala.reflect.NameTransformer
 import scala.collection.mutable

--- a/src/main/scala/StringParser.scala
+++ b/src/main/scala/StringParser.scala
@@ -1,6 +1,5 @@
 package d_m
 
-import scala.reflect.macros.ParseException
 import scala.tools.nsc.Global
 import scala.tools.nsc.reporters.StoreReporter
 


### PR DESCRIPTION
`-Xlint` tries to be extra helpful in 2.12.2, noted in community build.