### PR TITLE
Syntax for polymorphic values.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ scalacOptions in Test ++= {
 
 scalacOptions in Test += "-Yrangepos"
 
+scalacOptions in Test += "-P:kind-projector:forall=true"
+
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
 

--- a/src/main/scala/Extractors.scala
+++ b/src/main/scala/Extractors.scala
@@ -41,4 +41,30 @@ trait Extractors {
       case _                                                            => None
     }
   }
+  object TermNuType {
+    private val NuName = newTermName("ν")
+
+    def unapply(tree: Tree): Option[Tree] = tree match {
+      case TypeApply(Ident(name), tpe :: Nil) if name == NuName => Some(tpe)
+      case _                                                    => None
+    }
+  }
+  object PolyVal {
+    def unapply(tree: Tree): Option[(Tree, TermName, List[Tree], Tree)] = tree match {
+
+      // ν[T].method[A, B, ...](e)
+      case Apply(TypeApply(Select(TermNuType(tpe), method), tParams), body :: Nil) => Some((tpe, method.toTermName, tParams, body))
+
+      // ν[T][A, B, ...](e)
+      case Apply(TypeApply(TermNuType(tpe), tParams), body :: Nil)                 => Some((tpe, nme.apply, tParams, body))
+
+      // ν[T].method(e)
+      case Apply(Select(TermNuType(tpe), method), body :: Nil)                     => Some((tpe, method.toTermName, Nil, body))
+
+      // ν[T](e)
+      case Apply(TermNuType(tpe), body :: Nil)                                     => Some((tpe, nme.apply, Nil, body))
+
+      case _                                                                       => None
+    }
+  }
 }

--- a/src/main/scala/Extractors.scala
+++ b/src/main/scala/Extractors.scala
@@ -41,6 +41,14 @@ trait Extractors {
       case _                                                            => None
     }
   }
+  object TermLambda {
+    private val LambdaName = newTermName("Λ")
+
+    def unapply(tree: Tree): Option[(List[Tree], Tree)] = tree match {
+      case Apply(TypeApply(Ident(name), tParams), body :: Nil) if name == LambdaName => Some((tParams, body))
+      case _                                                                         => None
+    }
+  }
   object TermNuType {
     private val NuName = newTermName("ν")
 
@@ -51,6 +59,9 @@ trait Extractors {
   }
   object PolyVal {
     def unapply(tree: Tree): Option[(Tree, TermName, List[Tree], Tree)] = tree match {
+
+      // Λ[A, B, ...](e) : T
+      case Typed(TermLambda(tParams, body), tpe)                                   => Some((tpe, nme.apply, tParams, body))
 
       // ν[T].method[A, B, ...](e)
       case Apply(TypeApply(Select(TermNuType(tpe), method), tParams), body :: Nil) => Some((tpe, method.toTermName, tParams, body))

--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -128,7 +128,60 @@ class KindRewriter(plugin: Plugin, val global: Global)
     def makeTypeParamContra(name: Name, bounds: TypeBoundsTree = DefaultBounds): TypeDef =
       TypeDef(Modifiers(PARAM | CONTRAVARIANT), makeTypeName(name), Nil, bounds)
 
-    def polyLambda(tree: Tree): Tree = tree match {
+    // Given a name, e.g. A or `+A` or `A <: Foo`, build a type
+    // parameter tree using the given name, bounds, variance, etc.
+    def makeTypeParamFromName(ident: Ident): TypeDef = {
+      val decoded = NameTransformer.decode(ident.name.toString)
+      val src = s"type _X_[$decoded] = Unit"
+      sp.parse(src) match {
+        case Some(TypeDef(_, _, List(tpe), _)) => tpe.duplicate
+        case None => reporter.error(ident.pos, s"Can't parse param: ${ident.name}"); null
+      }
+    }
+
+    // Like makeTypeParam, but can be used recursively in the case of types
+    // that are themselves parameterized.
+    def makeComplexTypeParam(t: Tree): TypeDef = t match {
+      case id @ Ident(_) =>
+        makeTypeParamFromName(id)
+
+      case AppliedTypeTree(Ident(name), ps) =>
+        val tparams = ps.map(makeComplexTypeParam)
+        TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
+
+      case ExistentialTypeTree(AppliedTypeTree(Ident(name), ps), _) =>
+        val tparams = ps.map(makeComplexTypeParam)
+        TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
+
+      case x =>
+        reporter.error(x.pos, "Can't parse %s (%s)" format (x, x.getClass.getName))
+        null.asInstanceOf[TypeDef]
+    }
+
+    def typeArgsToTypeParams(args: List[Tree]): List[TypeDef] = args.map {
+      case id @ Ident(_) =>
+        makeTypeParamFromName(id)
+
+      case AppliedTypeTree(Ident(Plus), Ident(name) :: Nil) =>
+        makeTypeParamCo(name)
+
+      case AppliedTypeTree(Ident(Minus), Ident(name) :: Nil) =>
+        makeTypeParamContra(name)
+
+      case AppliedTypeTree(Ident(name), ps) =>
+        val tparams = ps.map(makeComplexTypeParam)
+        TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
+
+      case ExistentialTypeTree(AppliedTypeTree(Ident(name), ps), _) =>
+        val tparams = ps.map(makeComplexTypeParam)
+        TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
+
+      case x =>
+        reporter.error(x.pos, "Can't parse %s (%s)" format (x, x.getClass.getName))
+        null.asInstanceOf[TypeDef]
+    }
+
+    def polyTerm(tree: Tree): Tree = tree match {
       case PolyLambda(methodName, (arrowType @ UnappliedType(_ :: targs)) :: Nil, Function1Tree(name, body)) =>
         val (f, g) = targs match {
           case a :: b :: Nil => (a, b)
@@ -139,41 +192,20 @@ class KindRewriter(plugin: Plugin, val global: Global)
         atPos(tree.pos.makeTransparent)(
           q"new $arrowType { def $methodName[$TParam]($name: $f[$TParam]): $g[$TParam] = $body }"
         )
+      case PolyVal(targetType, methodName, tArgs, body) =>
+        atPos(tree.pos.makeTransparent)(tArgs match {
+          case Nil =>
+            val tParam = newTypeName(freshName("A"))
+            q"new $targetType { def $methodName[$tParam] = $body }"
+          case _ =>
+            val tParams = typeArgsToTypeParams(tArgs)
+            q"new $targetType { def $methodName[..$tParams] = $body }"
+        })
       case _ => tree
     }
 
     // The transform method -- this is where the magic happens.
     override def transform(tree: Tree): Tree = {
-
-      // Given a name, e.g. A or `+A` or `A <: Foo`, build a type
-      // parameter tree using the given name, bounds, variance, etc.
-      def makeTypeParamFromName(name: Name): TypeDef = {
-        val decoded = NameTransformer.decode(name.toString)
-        val src = s"type _X_[$decoded] = Unit"
-        sp.parse(src) match {
-          case Some(TypeDef(_, _, List(tpe), _)) => tpe
-          case None => reporter.error(tree.pos, s"Can't parse param: $name"); null
-        }
-      }
-
-      // Like makeTypeParam, but can be used recursively in the case of types
-      // that are themselves parameterized.
-      def makeComplexTypeParam(t: Tree): TypeDef = t match {
-        case Ident(name) =>
-          makeTypeParamFromName(name)
-
-        case AppliedTypeTree(Ident(name), ps) =>
-          val tparams = ps.map(makeComplexTypeParam)
-          TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
-
-        case ExistentialTypeTree(AppliedTypeTree(Ident(name), ps), _) =>
-          val tparams = ps.map(makeComplexTypeParam)
-          TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
-
-        case x =>
-          reporter.error(x.pos, "Can't parse %s (%s)" format (x, x.getClass.getName))
-          null.asInstanceOf[TypeDef]
-      }
 
       // Given the list a::as, this method finds the last argument in the list
       // (the "subtree") and returns that separately from the other arguments.
@@ -205,28 +237,7 @@ class KindRewriter(plugin: Plugin, val global: Global)
       // Lambda[(A, B) => Function2[A, Int, B]] case.
       def handleLambda(a: Tree, as: List[Tree]): Tree = {
         val (args, subtree) = parseLambda(a, as, Nil)
-        val innerTypes = args.map {
-          case Ident(name) =>
-            makeTypeParamFromName(name)
-
-          case AppliedTypeTree(Ident(Plus), Ident(name) :: Nil) =>
-            makeTypeParamCo(name)
-
-          case AppliedTypeTree(Ident(Minus), Ident(name) :: Nil) =>
-            makeTypeParamContra(name)
-
-          case AppliedTypeTree(Ident(name), ps) =>
-            val tparams = ps.map(makeComplexTypeParam)
-            TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
-
-          case ExistentialTypeTree(AppliedTypeTree(Ident(name), ps), _) =>
-            val tparams = ps.map(makeComplexTypeParam)
-            TypeDef(Modifiers(PARAM), makeTypeName(name), tparams, DefaultBounds)
-
-          case x =>
-            reporter.error(x.pos, "Can't parse %s (%s)" format (x, x.getClass.getName))
-            null.asInstanceOf[TypeDef]
-        }
+        val innerTypes = typeArgsToTypeParams(args)
         makeTypeProjection(innerTypes, subtree)
       }
 
@@ -322,7 +333,7 @@ class KindRewriter(plugin: Plugin, val global: Global)
       // given a tree, see if it could possibly be a type lambda
       // (either placeholder syntax or lambda syntax). if so, handle
       // it, and if not, transform it in the normal way.
-      val result = polyLambda(tree match {
+      val result = polyTerm(tree match {
 
         // Lambda[A => Either[A, Int]] case.
         case AppliedTypeTree(Ident(TypeLambda1), AppliedTypeTree(target, a :: as) :: Nil) =>

--- a/src/test/scala/polylambda.scala
+++ b/src/test/scala/polylambda.scala
@@ -2,15 +2,18 @@ package d_m
 
 import org.junit.Test
 
-trait ~>[-F[_], +G[_]] {
-  def apply[A](x: F[A]): G[A]
-}
-trait ~>>[-F[_], +G[_]] {
-  def dingo[B](x: F[B]): G[B]
-}
 final case class Const[A, B](getConst: A)
 
 class PolyLambdas {
+
+  trait ~>[-F[_], +G[_]] {
+    def apply[A](x: F[A]): G[A]
+  }
+
+  trait ~>>[-F[_], +G[_]] {
+    def dingo[B](x: F[B]): G[B]
+  }
+
   type ToSelf[F[_]] = F ~> F
 
   val kf1 = Lambda[Option ~> Vector](_.toVector)

--- a/src/test/scala/polyval.scala
+++ b/src/test/scala/polyval.scala
@@ -1,0 +1,90 @@
+package d_m
+
+import org.junit.Test
+
+class PolyVals {
+
+  trait Forall[F[_]] {
+    def apply[A]: F[A]
+  }
+
+  trait Forall2[F[_, _]] {
+    def apply[A, B]: F[A, B]
+  }
+
+  trait ForallK[F[_[_]]] {
+    def apply[G[_]]: F[G]
+  }
+
+
+  trait Semigroup[A] {
+    def combine(x: A, y: A): A
+  }
+
+  def listSemigroup[A]: Semigroup[List[A]] = new Semigroup[List[A]] {
+    def combine(x: List[A], y: List[A]): List[A] = x ++ y
+  }
+
+  trait Functor[F[_]]
+  trait Monad[F[_]] {
+    def functor: Functor[F]
+  }
+
+  // universally quantified semigroup
+  type SemigroupK[F[_]] = Forall[λ[α => Semigroup[F[α]]]]
+
+  // natural transformations
+  type ~>[F[_]   , G[_]   ] = Forall [λ[α    => F[α] => G[α]]]
+  type ≈>[F[_[_]], G[_[_]]] = ForallK[λ[α[_] => F[α] => G[α]]]
+
+  // Const functor and constructors
+  type ConstA[A] = Forall[Const[A, ?]]
+  type ConstMaker1 = Forall[λ[α => α => ConstA[α]]]
+  type ConstMaker2 = Forall2[λ[(α, β) => α => Const[α, β]]]
+
+  // existentials via universals
+  type Consumer[F[_], R] = Forall[λ[A => F[A] => R]]
+  type Exists[F[_]] = Forall[λ[R => Consumer[F, R] => R]]
+  def existential[F[_], A](fa: F[A]): Exists[F] = ν[Exists[F]](_[A](fa))
+
+  @Test
+  def testSemigroupK(): Unit = {
+    val listSemigroupK = ν[SemigroupK[List]](listSemigroup)
+    assert(listSemigroupK[Int].combine(List(1, 2), List(3, 4)) == List(1, 2, 3, 4))
+  }
+
+  @Test
+  def testNaturalTransformations(): Unit = {
+    val headOption1 = ν[List ~> Option](_.headOption)
+    val headOption2 = ν[List ~> Option].apply[A]((l: List[A]) => l.headOption)
+
+    val monadToFunctor1 = ν[Monad ≈> Functor][F[_]](_.functor)
+    val monadToFunctor2 = ν[Monad ≈> Functor].apply[F[_]]((m: Monad[F]) => m.functor)
+
+    val listFunctor = new Functor[List] {}
+    val listMonad = new Monad[List] { def functor = listFunctor }
+
+    assert(headOption1[Int](List(1, 2)) == Some(1))
+    assert(headOption2[Int](List(1, 2)) == Some(1))
+    assert(monadToFunctor1[List](listMonad) == listFunctor)
+    assert(monadToFunctor2[List](listMonad) == listFunctor)
+  }
+
+  @Test
+  def testConst(): Unit = {
+    val const42 = ν[ConstA[Int]][B](new Const[Int, B](42))
+    val constMaker  = ν[ConstMaker1][A   ](a => ν[ConstA[A]][B](new Const[A, B](a)))
+    val constMaker2 = ν[ConstMaker2][A, B](a =>                 new Const[A, B](a) )
+
+    assert(const42[String].getConst == 42)
+    assert(constMaker[Int](42)[String].getConst == 42)
+    assert(constMaker2[Int, String](42).getConst == 42)
+  }
+
+  @Test
+  def testExistential(): Unit = {
+    val list = existential(List("one", "two", "three"))
+    val len = ν[Consumer[List, Int]](_.length)
+    assert(list[Int](len) == 3)
+  }
+}

--- a/src/test/scala/polyval.scala
+++ b/src/test/scala/polyval.scala
@@ -30,12 +30,15 @@ class PolyVals {
     def functor: Functor[F]
   }
 
+  final class Fun[A, B](val run: A => B)
+
   // universally quantified semigroup
   type SemigroupK[F[_]] = Forall[λ[α => Semigroup[F[α]]]]
 
   // natural transformations
-  type ~>[F[_]   , G[_]   ] = Forall [λ[α    => F[α] => G[α]]]
-  type ≈>[F[_[_]], G[_[_]]] = ForallK[λ[α[_] => F[α] => G[α]]]
+  type  ~>[F[_]   , G[_]   ] = Forall [λ[α      => F[α]    => G[α]]]
+  type  ≈>[F[_[_]], G[_[_]]] = ForallK[λ[α[_]   => F[α]    => G[α]]]
+  type ~~>[F[_, _], G[_, _]] = Forall2[λ[(α, β) => F[α, β] => G[α, β]]]
 
   // Const functor and constructors
   type ConstA[A] = Forall[Const[A, ?]]
@@ -61,6 +64,8 @@ class PolyVals {
     val monadToFunctor1 = ν[Monad ≈> Functor][F[_]](_.functor)
     val monadToFunctor2 = ν[Monad ≈> Functor].apply[F[_]]((m: Monad[F]) => m.functor)
 
+    val fun = Λ[A, B](new Fun(_)): Function1 ~~> Fun
+
     val listFunctor = new Functor[List] {}
     val listMonad = new Monad[List] { def functor = listFunctor }
 
@@ -68,6 +73,7 @@ class PolyVals {
     assert(headOption2[Int](List(1, 2)) == Some(1))
     assert(monadToFunctor1[List](listMonad) == listFunctor)
     assert(monadToFunctor2[List](listMonad) == listFunctor)
+    assert(fun[String, Int](_.length).run("foo") == 3)
   }
 
   @Test


### PR DESCRIPTION
This is another attempt at convenient syntax for polymorphic values. This PR addresses #37 and supersedes #44.

The syntax

```scala
ν[T].m[A, B[_], ...](e)
```

is rewritten to

```scala
new T { def m[A, B[_], ...] = e }
```

(The symbol "ν" is the Greek lowercase letter "Nu" (/njuː/) and stands for `new`.)

In case `m` has just one *-kinded type parameter which is not referenced from `e`, it can be omitted:

```scala
ν[T].m(e)
```

is rewritten to

```scala
new T { def m[A] = e }
```

where `A` is a fresh name.

If the method name is `apply`, it can be omitted:

```scala
ν[T][A, B[_], ...](e)
```

is rewritten to


```scala
new T { def apply[A, B[_], ...] = e }
```

The previous two shortcuts can be combined:

```scala
ν[T](e)
```

is rewritten to

```scala
new T { def apply[A] = e }
```

where `A` is a fresh name.

There is also an alternative syntax using Λ (Greek uppercase letter Lambda)

```scala
Λ[A, B[_], ...](e): T
```

which is equivalent to

```scala
ν[T][A, B[_], ...](e)
```

i.e.

```scala
new T { def apply[A, B[_], ...] = e }
```

When using Λ-syntax, type parameters cannot be omitted, and method name is (currently) assumed to be `apply`. Note also that the type `T` of the whole Λ-expression has to be specified (cannot be inferred, since kind-projector runs before typer).

See the test cases in `polyval.scala` for some examples.