### PR TITLE
Explicitly require to run before namer.

### DIFF
--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -26,6 +26,7 @@ class KindRewriter(plugin: Plugin, val global: Global)
   val sp = new StringParser[global.type](global)
 
   val runsAfter = "parser" :: Nil
+  override val runsBefore = "namer" :: Nil
   val phaseName = "kind-projector"
 
   lazy val useAsciiNames: Boolean =


### PR DESCRIPTION
Otherwise, it was just a lucky coincidence that kind-projector ran before `namer`.

Indeed, if I changed the phase name from `kind-projector` to `nameq`, it still worked, whereas when I changed it to `names` it stopped working. So it appears that currently we depend on the fact that "kind-projector" comes lexicographically before "namer".