### PR TITLE
published 0.9.5 for scala 2.13.0-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 homepage := Some(url("http://github.com/non/kind-projector"))
 
 scalaVersion := "2.11.11"
-crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2", "2.13.0-M1")
+crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2", "2.13.0-M2")
 
 libraryDependencies += scalaOrganization.value % "scala-compiler" % scalaVersion.value
 libraryDependencies ++= (scalaBinaryVersion.value match {
@@ -45,7 +45,7 @@ libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
 
 fork in Test := true
-libraryDependencies += "org.ensime" %% "pcplod" % "1.2.1" % Test
+libraryDependencies += "org.ensime" %% "pcplod" % "1.2.2" % Test
 javaOptions in Test ++= Seq(
   s"""-Dpcplod.settings=${(scalacOptions in Test).value.mkString(",")}""",
   s"""-Dpcplod.classpath=${(fullClasspath in Test).value.map(_.data).mkString(",")}"""


### PR DESCRIPTION
Everything seems to work fine with a `publishLocal`. Unfortunately this PR relies on a new version of `pcplod` which is [unpublished yet](https://github.com/ensime/pcplod/pull/28).