### PR TITLE
Use `*` as a placeholder in addition to `?`.

### DIFF
--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -51,18 +51,24 @@ class KindRewriter(plugin: Plugin, val global: Global)
     // Reserve some names
     val TypeLambda1 = newTypeName("Lambda")
     val TypeLambda2 = newTypeName("λ")
-    val InvPlaceholder = newTypeName("$qmark")
-    val CoPlaceholder = newTypeName("$plus$qmark")
-    val ContraPlaceholder = newTypeName("$minus$qmark")
+    object InvPlaceholder  {
+      def unapply(name: TypeName): Boolean = name == newTypeName("$qmark") || name == newTypeName("$times")
+    }
+    object CoPlaceholder {
+      def unapply(name: TypeName): Boolean = name == newTypeName("$plus$qmark") || name == newTypeName("$plus$times")
+    }
+    object ContraPlaceholder {
+      def unapply(name: TypeName): Boolean = name == newTypeName("$minus$qmark") || name == newTypeName("$minus$times")
+    }
 
     val TermLambda1 = TypeLambda1.toTermName
     val TermLambda2 = TypeLambda2.toTermName
 
     object Placeholder {
       def unapply(name: TypeName): Option[Variance] = name match {
-        case InvPlaceholder => Some(Invariant)
-        case CoPlaceholder => Some(Covariant)
-        case ContraPlaceholder => Some(Contravariant)
+        case InvPlaceholder() => Some(Invariant)
+        case CoPlaceholder() => Some(Covariant)
+        case ContraPlaceholder() => Some(Contravariant)
         case _ => None
       }
     }

--- a/src/test/scala/test.scala
+++ b/src/test/scala/test.scala
@@ -16,6 +16,7 @@ object Test {
   // used to test the plugin
   bar[Either[Int, ?]]
   baz[Tuple3[Int, ?, ?]]
+  baz[Tuple3[*, Int, *]]
 
   // should not be changed by the plugin
   foo[Either[Int, Double]]
@@ -42,6 +43,7 @@ object Test {
   trait EitherT[F[_], A, B]
   qux[Functor[?[_]]]
   qux[EitherT[?[_], Int, Double]]
+  qux[EitherT[*[_], Int, Double]]
 
   // higher higher order
   def vex[T[_[_[_]]]] = ()
@@ -69,6 +71,7 @@ object Test {
   def bux[T[-_, +_]] = ()
   bux[({type L[-A, +B] = Function2[A, Int, B]})#L]
   bux[Function2[-?, Int, +?]]
+  bux[Function2[-*, Int, +*]]
   bux[Lambda[(`-A`, `+B`) => Function2[A, Int, B]]]
   bux[Lambda[(-[A], +[B]) => Function2[A, Int, B]]]
 
@@ -77,7 +80,9 @@ object Test {
   def tux[T[-F[_]]] = ()
   def hux[T[+G[_]]] = ()
   tux[~>[-?[_], Option]]
+  tux[~>[-*[_], Option]]
   hux[~>[Option, +?[_]]]
+  hux[~>[Option, +*[_]]]
   tux[Lambda[`-F[_]` => ~>[F, Option]]]
   hux[Lambda[`+G[_]` => ~>[Option, G]]]
 }


### PR DESCRIPTION
**Motivation:**
There is a proposal for `F[?]` to denote a wildcard (currently `F[_]`) in Scala 3.0+ and `F[_]` to be a shorthand syntax for type lambda (`F[?]` with current kind-projector syntax) in Scala 3.3+ (see
https://github.com/lampepfl/dotty/issues/5379).

Supporting an additional placeholder will allow users to gradually move from `?` to `*` before Scala 3.0 is out.

Resolves #84.