### PR TITLE
fix some code to compile on latest 2.13 nightly

### DIFF
--- a/src/main/scala/KindProjector.scala
+++ b/src/main/scala/KindProjector.scala
@@ -43,7 +43,7 @@ class KindRewriter(plugin: Plugin, val global: Global)
     // using kp with hlists was too costly.
     val treeCache = mutable.Map.empty[Tree, Tree]
 
-    sealed abstract class Variance(val modifiers: Int)
+    sealed abstract class Variance(val modifiers: Long)
     case object Invariant extends Variance(0)
     case object Covariant extends Variance(COVARIANT)
     case object Contravariant extends Variance(CONTRAVARIANT)


### PR DESCRIPTION
this change should be fine on other Scala versions too.  Flags are
Longs, always have been, the compiler is just pickier now about
coercing Longs to Ints